### PR TITLE
Optimizes useCheckoutPricing useEffect hook

### DIFF
--- a/lib/use-checkout-pricing.js
+++ b/lib/use-checkout-pricing.js
@@ -72,63 +72,63 @@ export default function useCheckoutPricing(initialInputs = {}, handleError = thr
         handleError(error);
         setLoading(false);
       });
-  }, [input]);
 
-  function addAdjustments (adjustments, checkoutPricing) {
-    return adjustments
-      .reduce((checkoutPricing, adjustment) => {
-        if (adjustment.itemCode) {
-          return checkoutPricing.adjustment(adjustment);
-        }
-        return checkoutPricing;
-      }, checkoutPricing).catch(handleError)
-  };
+    function addAdjustments (adjustments, checkoutPricing) {
+      return adjustments
+        .reduce((checkoutPricing, adjustment) => {
+          if (adjustment.itemCode) {
+            return checkoutPricing.adjustment(adjustment);
+          }
+          return checkoutPricing;
+        }, checkoutPricing).catch(handleError);
+    };
 
-  function addRestInputs(restInputs, checkoutPricing) {
-    const { PRICING_METHODS } = checkoutPricing;
-    const exclude = ['reset', 'remove', 'reprice', 'subscriptions', 'adjustments', 'addon', 'plan'];
-    const permittedInputs = PRICING_METHODS.filter(method => !exclude.includes(method));
+    function addRestInputs(restInputs, checkoutPricing) {
+      const { PRICING_METHODS } = checkoutPricing;
+      const exclude = ['reset', 'remove', 'reprice', 'subscriptions', 'adjustments', 'addon', 'plan'];
+      const permittedInputs = PRICING_METHODS.filter(method => !exclude.includes(method));
 
-    return Object.entries(restInputs).reduce((acc, input) => {
-      const [method, value] = input;
-      const shouldCallPricingMethod = value && permittedInputs.includes(method);
-      return shouldCallPricingMethod ? acc[method](value).catch(handleError) : acc;
-    }, checkoutPricing);
-  };
+      return Object.entries(restInputs).reduce((acc, input) => {
+        const [method, value] = input;
+        const shouldCallPricingMethod = value && permittedInputs.includes(method);
+        return shouldCallPricingMethod ? acc[method](value).catch(handleError) : acc;
+      }, checkoutPricing);
+    };
 
-  function addSubscriptions(subscriptions, checkoutPricing) {
-    const { subscriptionPricings } = subscriptions.reduce(
-      ({ checkoutPricing, subscriptionPricings }, { plan, tax, addons = [], quantity }) => {
-        let subscriptionPricing = recurly.Pricing.Subscription().plan(plan, { quantity });
+    function addSubscriptions(subscriptions, checkoutPricing) {
+      const { subscriptionPricings } = subscriptions.reduce(
+        ({ checkoutPricing, subscriptionPricings }, { plan, tax, addons = [], quantity }) => {
+          let subscriptionPricing = recurly.Pricing.Subscription().plan(plan, { quantity });
 
-        if (addons.length) {
-          subscriptionPricing = addAddons(addons, subscriptionPricing);
-        }
+          if (addons.length) {
+            subscriptionPricing = addAddons(addons, subscriptionPricing);
+          }
 
-        if (tax) {
-          subscriptionPricing = subscriptionPricing.tax(tax);
-        }
+          if (tax) {
+            subscriptionPricing = subscriptionPricing.tax(tax);
+          }
 
-        subscriptionPricing = subscriptionPricing.catch(handleError);
+          subscriptionPricing = subscriptionPricing.catch(handleError);
 
-        return {
-          checkoutPricing: checkoutPricing.subscription(subscriptionPricing.done()),
-          subscriptionPricings: [...subscriptionPricings, subscriptionPricing],
-        };
-      },
-      { checkoutPricing, subscriptionPricings: [] },
-    );
+          return {
+            checkoutPricing: checkoutPricing.subscription(subscriptionPricing.done()),
+            subscriptionPricings: [...subscriptionPricings, subscriptionPricing],
+          };
+        },
+        { checkoutPricing, subscriptionPricings: [] },
+      );
 
-    return Promise.all(subscriptionPricings);
-  };
+      return Promise.all(subscriptionPricings);
+    };
 
-  function addAddons(addons = [], subscriptionPricing) {
-    return addons
-      .reduce((subscriptionPricing, { code, quantity }) => {
-        return subscriptionPricing.addon(code, { quantity });
-      }, subscriptionPricing)
-      .catch(handleError);
-  };
+    function addAddons(addons = [], subscriptionPricing) {
+      return addons
+        .reduce((subscriptionPricing, { code, quantity }) => {
+          return subscriptionPricing.addon(code, { quantity });
+        }, subscriptionPricing)
+        .catch(handleError);
+    };
+  }, [input, handleError, recurly.Pricing]);
 
   const output = {
     price: (pricing && cloneDeep(pricing.price)) || {},


### PR DESCRIPTION
Optimizing useEffect hook inside useCheckoutPricing to run its hook ONLY when the input object is changed. See https://codesandbox.io/s/sweet-breeze-n1s97 for a basic example of this.

In its current implementation, anytime a consumer calls `setPricing`, the hook is run. This optimization prevents the hook from running unnecessarily if `setPricing` gets called with the same `input`.

This also resolves a warning emitted from the eslint's exhaustive-deps plugin: https://github.com/facebook/react/issues/14920.

Extra note: The diff is misleadingly large. Functions that were called inside the `useEffect` had to be moved inside the scope of the hook as for `exhaustive-deps`, but are unchanged.
