### PR TITLE
Updates useRecurly to set correct prototype on copied recurly instance

### DIFF
--- a/lib/use-recurly.js
+++ b/lib/use-recurly.js
@@ -15,11 +15,12 @@ export default function useRecurly () {
   }
 
   const { elements } = elementsContext;
-  const { recurly } = elements
-
-  return {
-    ...recurly,
+  const recurly = {
+    ...elements.recurly,
     // Provide a curried token method to bind the elements from the closest context
-    token: (...args) => recurly.token(elements, ...args)
-  };
+    token: (...args) => elements.recurly.token(elements, ...args)
+  }
+
+  Object.setPrototypeOf(recurly, elements.recurly);
+  return recurly;
 }

--- a/test/use-recurly.test.js
+++ b/test/use-recurly.test.js
@@ -41,6 +41,7 @@ describe('useRecurly', function () {
         const recurly = useRecurly();
         expect(recurly.token).toBeInstanceOf(Function);
         expect(recurly.config.publicKey).toBe('test-public-key');
+        expect(recurly).toBeInstanceOf(window.recurly.Recurly);
         return '';
       }
     });


### PR DESCRIPTION
Calling PayPal on the result of useRecurly throws this error:

```
const recurly = useRecurly();

const paypal = recurly.PayPal({
  display: {
    displayName: 'Test',
    description: 'Test description'
  }
});
```

![image](https://user-images.githubusercontent.com/32269552/77452493-000b9c80-6dc4-11ea-9bf5-2d8fa880724d.png)

Which originates here: https://github.com/recurly/recurly-js/blob/master/lib/recurly/paypal/strategy/index.js#L52

Currently, the prototype of the returned value of useRecurly() is `Object`: https://github.com/recurly/react-recurly/blob/master/lib/use-recurly.js#L20

This updates `useRecurly` to set the correct prototype on the returned recurly instance.