### PR TITLE
Fixes small error in demo

### DIFF
--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -101,6 +101,5 @@
 
   <body>
     <div class="App"></div>
-    <script src="/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This script tag is unnecessary, as react-scripts is injecting the script on the page through webpack.

This fixes this error from displaying in console: 

![image](https://user-images.githubusercontent.com/32269552/77921144-fde28b80-7264-11ea-8ffa-837d2e933ea4.png)

Note: the error and this fix have no impact on actual functionality as far as I can tell.