### PR TITLE
Fixes issue with useCheckoutPricing currency

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   collectCoverage: true,
   coverageDirectory: './build/reports/coverage/',
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js', 'jest-extended'],
   transformIgnorePatterns: ['/node_modules/(?!recurly.js).+\\.js$'],
   transform: {
     '^.+\\.js$': 'babel-jest',

--- a/lib/use-checkout-pricing.js
+++ b/lib/use-checkout-pricing.js
@@ -53,14 +53,6 @@ export default function useCheckoutPricing (initialInputs, handleError = throwEr
     const { subscriptions = [], adjustments = [], ...restInputs } = input;
     let checkoutPricing = recurly.Pricing.Checkout();
 
-    if (Object.keys(restInputs).length) {
-      checkoutPricing = addRestInputs(restInputs, checkoutPricing);
-    };
-
-    if (adjustments.length) {
-      checkoutPricing = addAdjustments(adjustments, checkoutPricing);
-    };
-
     addSubscriptions(subscriptions, checkoutPricing)
       .then(() => {
         checkoutPricing = checkoutPricing.reprice().done(() => {
@@ -72,6 +64,14 @@ export default function useCheckoutPricing (initialInputs, handleError = throwEr
         handleError(error);
         setLoading(false);
       });
+
+    if (adjustments.length) {
+      checkoutPricing = addAdjustments(adjustments, checkoutPricing);
+    };
+
+    if (Object.keys(restInputs).length) {
+      checkoutPricing = addRestInputs(restInputs, checkoutPricing);
+    };
 
     function addAdjustments (adjustments, checkoutPricing) {
       return adjustments

--- a/package-lock.json
+++ b/package-lock.json
@@ -12434,6 +12434,52 @@
         "jest-util": "^24.9.0"
       }
     },
+    "jest-extended": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-0.11.5.tgz",
+      "integrity": "sha512-3RsdFpLWKScpsLD6hJuyr/tV5iFOrw7v6YjA3tPdda9sJwoHwcMROws5gwiIZfcwhHlJRwFJB2OUvGmF3evV/Q==",
+      "dev": true,
+      "requires": {
+        "expect": "^24.1.0",
+        "jest-get-type": "^22.4.3",
+        "jest-matcher-utils": "^22.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+          "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+          "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "pretty-format": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        }
+      }
+    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "jest": "^24.9.0",
+    "jest-extended": "^0.11.5",
     "jest-transform-css": "^2.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/test/use-checkout-pricing.test.js
+++ b/test/use-checkout-pricing.test.js
@@ -207,6 +207,44 @@ describe('useCheckoutPricing', function() {
     });
   });
 
+  describe('Call order', () => {
+    it('should call checkoutPricing.subscriptions before checkoutPricing.adjustments', async () => {
+      const initialInput = {
+        subscriptions: [{ plan: 'basic' }],
+        adjustments: { itemCode: 'item-1', quantity: 2 },
+      };
+
+      renderUseCheckoutPricing(initialInput);
+
+      await act(async () => {
+        setTimeout(() => {
+          expect(checkoutPricingReturn.subscription).toHaveBeenCalled();
+          expect(checkoutPricingReturn.adjustment).toHaveBeenCalled();
+          expect(checkoutPricingReturn.subscription)
+            .toHaveBeenCalledBefore(checkoutPricingReturn.adjustment);
+        }, 10);
+      });
+    });
+
+    it('should call checkoutPricing.adjustments before checkoutPricing rest inputs', async () => {
+      const initialInput = {
+        currency: "USD",
+        adjustments: { itemCode: 'item-1', quantity: 2 },
+      };
+
+      renderUseCheckoutPricing(initialInput);
+
+      await act(async () => {
+        setTimeout(() => {
+          expect(checkoutPricingReturn.currency).toHaveBeenCalled();
+          expect(checkoutPricingReturn.adjustment).toHaveBeenCalled();
+          expect(checkoutPricingReturn.adjustment)
+            .toHaveBeenCalledBefore(checkoutPricingReturn.currency);
+        }, 10);
+      });
+    });
+  });
+
   describe('Error handler', () => {
     it('should be passed to .catch', async () => {
       const handleError = jest.fn();
@@ -218,7 +256,7 @@ describe('useCheckoutPricing', function() {
           expect(handleError).toHaveBeenCalled();
           expect(checkoutPricingReturn.catch).toHaveBeenCalled();
           expect(subscriptionPricingReturn.catch).toHaveBeenCalled();
-        }, 5);
+        }, 10);
       });
     });
   });


### PR DESCRIPTION
We discovered an issue with useCheckoutPricing not raising an error when passing a currency that isn't accepted on a plan.

To fix the issue, we needed to rearrange the call order inside `useCheckoutPricing` to call subscriptions first, then adjustments,
then everything else.

To add an assertion for this, I also added `jest-extended` for its `toHaveBeenCalledBefore` matcher.