### PR TITLE
Fixes currency symbol character encoding in demo

### DIFF
--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -4,6 +4,7 @@
     <title>demo | react-recurly</title>
     <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
     <link rel="stylesheet" href="https://js.recurly.com/v4/recurly.css" />
+    <meta charset="utf-8" />
     <script src="https://js.recurly.com/v4/recurly.js"></script>
     <style>
       * {


### PR DESCRIPTION
This fixes an issue with currency symbol character coding that emerges in the code sandbox demo, but not in the demo locally.

Before:

![image](https://user-images.githubusercontent.com/32269552/81213584-33813f80-8f9c-11ea-8678-2871d12f3228.png)

After:

![image](https://user-images.githubusercontent.com/32269552/81213543-1cdae880-8f9c-11ea-9aa3-a21f76799dfc.png)
