### PR TITLE
Fixes type for useCheckoutPricing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -183,4 +183,4 @@ export function useRecurly(): UseRecurlyInstance;
  * to interact with the Recurly.js pricing API and provide users with an
  * estimate of a purchase before they check out.
  */
-export function useCheckoutPricing(input: UseCheckoutPricingInput): UseCheckoutPricingReturn;
+export function useCheckoutPricing(input: UseCheckoutPricingInput, handleError?: (error: RecurlyError) => any): UseCheckoutPricingReturn;

--- a/types/test-types.tsx
+++ b/types/test-types.tsx
@@ -16,6 +16,7 @@ import {
   IndividualElementChangeEvent,
   UseCheckoutPricingInput
 } from '@recurly/react-recurly';
+import { RecurlyError } from '@recurly/recurly-js';
 
 function TestComponent() {
   const recurly = useRecurly();
@@ -163,7 +164,9 @@ function TestComponent() {
     }
   };
 
-  const [{ price, loading }, setPricing] = useCheckoutPricing(checkoutPricingInput);
+  useCheckoutPricing(checkoutPricingInput);
+
+  const [{ price, loading }, setPricing] = useCheckoutPricing(checkoutPricingInput, (e: RecurlyError) => {});
 
   setPricing(checkoutPricingInput);
   // $ExpectError


### PR DESCRIPTION
Correctly adds a second optional parameter for `useCheckoutPricing` typed as any function with the first argument as a `RecurlyError`