### PR TITLE
Fixes typo in docs for 3ds.actionTokenId

### DIFF
--- a/lib/three-d-secure-action.js
+++ b/lib/three-d-secure-action.js
@@ -15,7 +15,7 @@ export default class ThreeDSecureAction extends React.PureComponent {
     className: PropTypes.string,
 
     /**
-     * `three_d_secure_action_token_id`` returned by the Recurly API when 3-D Secure
+     * `three_d_secure_action_token_id` returned by the Recurly API when 3-D Secure
      * authentication is required for a transaction.
      */
     actionTokenId: PropTypes.string,


### PR DESCRIPTION
Currently, the docs look like this:

![image](https://user-images.githubusercontent.com/32269552/90789618-b8cefc80-e2cc-11ea-9413-044241ac476e.png)
