### PR TITLE
useCheckoutPricing will return its pricing instance

### DIFF
--- a/docs/shared/prop-types.js
+++ b/docs/shared/prop-types.js
@@ -45,4 +45,3 @@ export function propsSlotFor (component, ...rest) {
     ]
   })
 }
-

--- a/lib/use-checkout-pricing.js
+++ b/lib/use-checkout-pricing.js
@@ -135,7 +135,7 @@ export default function useCheckoutPricing (initialInputs, handleError = throwEr
     loading
   };
 
-  return [pricingState, setInput];
+  return [pricingState, setInput, pricing];
 };
 
 export function throwError(err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22740,7 +22740,7 @@
       }
     },
     "recurly.js": {
-      "version": "github:recurly/recurly-js#e9dfdfe88b64ce526009835a363375aae4f915ee",
+      "version": "github:recurly/recurly-js#a75a51fcd0d080242cff98032d58d0b42a1aede4",
       "from": "github:recurly/recurly-js",
       "dev": true,
       "requires": {
@@ -22762,7 +22762,7 @@
         "lodash.pick": "^4.4.0",
         "nanoid": "^2.1.9",
         "promise": "^8.0.3",
-        "qs": "^6.9.1",
+        "qs": "^6.9.4",
         "string-squish": "^1.0.3",
         "tabbable": "^4.0.0",
         "to-slug-case": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "homepage": "https://github.com/recurly/react-recurly#readme",
   "peerDependencies": {
-    "react": "^16.8.0-0",
-    "react-dom": "^16.8.0-0"
+    "react": ">= 16.8.0-0",
+    "react-dom": ">= 16.8.0-0"
   },
   "dependencies": {
     "@types/react": "^16.9.32",

--- a/test/use-checkout-pricing.test.js
+++ b/test/use-checkout-pricing.test.js
@@ -91,6 +91,21 @@ describe('useCheckoutPricing', function () {
       expect(price.next.total).toBe('24.99');
     });
 
+    test('a subscription with tax', async () => {
+      const { result, waitForNextUpdate } = renderUseCheckoutPricing({
+        subscriptions: [{
+          plan: 'basic',
+          tax: [{ code: 'physical-goods', amounts: { now: '2.00', next: '0.00' } }]
+        }]
+      });
+
+      await waitForNextUpdate();
+
+      const [{ price }] = result.current;
+      expect(price.now.total).toBe('21.99');
+      expect(price.next.total).toBe('19.99');
+    });
+
     test('a currency and a subscription, then an updated currency', async () => {
       const { result, waitForNextUpdate } = renderUseCheckoutPricing({
         currency: 'EUR',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,7 @@ import {
   Address,
   TokenHandler,
   CheckoutPrice,
+  CheckoutPricingInstance,
   Adjustment,
   RecurlyError,
   TokenPayload
@@ -101,7 +102,7 @@ export type UseCheckoutPricingState = {
 
 export type SetCheckoutPricing = (input: UseCheckoutPricingInput | ((prevState: UseCheckoutPricingInput) => UseCheckoutPricingInput)) => void;
 
-export type UseCheckoutPricingReturn = [UseCheckoutPricingState, SetCheckoutPricing];
+export type UseCheckoutPricingReturn = [UseCheckoutPricingState, SetCheckoutPricing, CheckoutPricingInstance];
 
 export type RiskStrategies = 'kount';
 


### PR DESCRIPTION
- This will expose the `CheckoutPricing` instance which underlies `useCheckoutPricing`
- Classes like `recurly.ApplePay` will accept a pricing instance -- this allows pricing generated by `useCheckoutPricing` to be passed along as the implementation requires.