### PR TITLE
fix(lib/provider.js): fix RecurlyProvider throwing error when fraud property is set

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -101,7 +101,8 @@ function fetchRecurlyInstance (options) {
   let cache = window.recurly.Recurly.__instanceCache = window.recurly.Recurly.__instanceCache || {};
   const key = JSON.stringify(options);
 
-  const recurly = cache[key] || new window.recurly.Recurly(options);
+  const recurly = cache[key] || new window.recurly.Recurly();
+  recurly.configure(options);
   cache[key] = recurly;
 
   return recurly;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6909,9 +6909,9 @@
       }
     },
     "@types/recurly__recurly-js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@types/recurly__recurly-js/-/recurly__recurly-js-4.12.2.tgz",
-      "integrity": "sha512-BxDIW2YnlMpyKLlZZJdZ6SM8dBBTepSLuQj+d0MwIZ25FkYJUW2Z5vSqFFIR0/+poZxda4mBiziQkKfjdKbzcA=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/recurly__recurly-js/-/recurly__recurly-js-4.16.0.tgz",
+      "integrity": "sha512-DuA4n/8fIMVtqgTCkY8mG04EV2Oa5l7Ol5+7l0MNN9CZtp/44UhTHJxT8sTzT4NzK1J5cUHibo1NLsD1Xsxdfw=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -22805,7 +22805,7 @@
         "lodash.pick": "^4.4.0",
         "nanoid": "^2.1.9",
         "promise": "^8.0.3",
-        "qs": "^6.9.3",
+        "qs": "^6.9.4",
         "string-squish": "^1.0.3",
         "tabbable": "^4.0.0",
         "to-slug-case": "^1.0.0"

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -64,6 +64,12 @@ describe('<RecurlyProvider />', function () {
       }).not.toThrow();
     });
 
+    it('does not throw an error when the fraud property is configured to be true', function () {
+      expect(() => {
+        render(<RecurlyProvider publicKey="test-public-key" api={api} fraud={{kount: {dataCollector: true}}} />);
+      }).not.toThrow();
+    });
+
     it('provides a Recurly instance', function () {
       render(
         <RecurlyProvider publicKey="test-public-key" api={api}>


### PR DESCRIPTION
When we set the fraud property on RecurlyProvider like so:
```
fraud={{kount: {dataCollector: true}}}
```

We get this error:
```
Error name:    "TypeError"
Error message: "Cannot read property 'get' of undefined"
```

in `node_modules/recurly.js/lib/recurly/fraud.js:63:26`
```
  attachDataCollector () {
    if (this.dataCollectorInitiated) return;
    this.dataCollectorInitiated = true;

    this.recurly.request.get({
      route: '/risk/info',
      done: (error, response) => {
        debug('risk info', error, response);
```

The problem seems to be with the way that recurly's constructor works—if you provide options in the constructor, then the configure event fires and the call to `risk/info` fails without a Request object being set yet. The way the recurly instance is set up here in this PR is more like your e2e tests in the recurly-js repo itself, so configuration happens _after_ everything gets set up, including the `request` property.
