### PR TITLE
Docs Fix: useRecurly Paypal example

### DIFF
--- a/docs/2-hooks/useRecurly.stories.mdx
+++ b/docs/2-hooks/useRecurly.stories.mdx
@@ -49,7 +49,7 @@ The example below shows how to use `useRecurly` to interact with the [Recurly-js
 
 ```jsx
 const PayPalButton = () => {
-  const { recurly } = useRecurly();
+  const recurly = useRecurly();
   const payPal = recurly.PayPal();
 
   useEffect(() => {


### PR DESCRIPTION
While going through the docs I saw a little typo on the Paypal example of the usage of `useRecurly`.

This PR addresses that in order to be the right one like in the rest of the docs where it's not wrong.