### PR TITLE
Docs fix: UseCheckoutPricingInput `subscriptions`

### DIFF
--- a/docs/3-types/useCheckoutPricingInput.stories.mdx
+++ b/docs/3-types/useCheckoutPricingInput.stories.mdx
@@ -18,7 +18,6 @@ A plain object used to set initial values for [useCheckoutPricing][use-checkout-
         detail: `[{
   plan: 'my-plan',
   quantity: 1,
-  currency: 'USD',
   addons: [{code: 'my-addon-code', quantity: 1}]
 }]`,
       },


### PR DESCRIPTION
There is an error also in [this section of the documentation](https://recurly.github.io/react-recurly/iframe.html?id=types-usecheckoutpricinginput--page&viewMode=docs).

**Current state**
![image](https://user-images.githubusercontent.com/5735272/136572211-96a8ae55-a274-4322-9773-02b95cf4cc7e.png)

`currency` cannot be passed in a subscription, `currency` is meant to be passed on the root level of `UseCheckoutPricingInput` and passing it on the subscription does absolutely nothing and should not be even passed according to the documentation [when you scroll down](https://recurly.github.io/react-recurly/iframe.html?id=types-usecheckoutpricinginput--page&viewMode=docs#subscription).

I am suggesting this change to avoid the confusion that went through me today for more time than I would care to admit.