### PR TITLE
setup element when didmount

### DIFF
--- a/lib/element/element.js
+++ b/lib/element/element.js
@@ -85,25 +85,26 @@ export default class Element extends React.PureComponent {
 
   constructor (props, context) {
     super(props, context);
-
     const { elementClassName } = this.constructor;
 
     if (!context || !context.elements) {
       throw new Error(`<${elementClassName}> must be within an <Elements> tree.`);
     }
 
-    const options = extractOptions(this.props);
-    const element = this._element = context.elements[elementClassName](options);
     this._container = React.createRef();
+  }
+
+  componentDidMount () {
+    const { elementClassName } = this.constructor;
+    const options = extractOptions(this.props);
+    const element = this._element = this.context.elements[elementClassName](options);
 
     element.on('ready', (...args) => this.props.onReady(...args));
     element.on('change', (...args) => this.props.onChange(...args));
     element.on('blur', (...args) => this.props.onBlur(...args));
     element.on('focus', (...args) => this.props.onFocus(...args));
     element.on('submit', (...args) => this.props.onSubmit(...args));
-  }
 
-  componentDidMount () {
     this._element.attach(this._container.current);
   }
 


### PR DESCRIPTION
## Why

React18 is providing concurrent feature, to this component specifically, it will need the component to mount and unmount couple times and got the same result, issue is surfaced by strict mode. see more information [here](https://reactjs.org/blog/2022/03/29/react-v18.html#new-strict-mode-behaviors),

The current implementation is setting up element events in constructor but destroy it when unmount, so when react18 unmount the component and mount again, element won't get setup again.

## Changes

- Move setup into didmount lifecycle. 