### PR TITLE
Risk data collector form passing

### DIFF
--- a/lib/risk-data-collector.js
+++ b/lib/risk-data-collector.js
@@ -69,7 +69,7 @@ export default class RiskDataCollector extends React.Component {
     const { _container: container, _recurly: recurly } = this;
     const { strategy, onError } = this.props;
 
-    recurly.configure({ fraud: { [strategy]: { dataCollector: true, form: container } } });
+    recurly.configure({ fraud: { [strategy]: { dataCollector: true, form: container.current } } });
     const fraud = this._fraud = recurly.fraud;
     fraud.on('error', (...args) => onError(...args));
   }

--- a/test/risk-data-collector.test.js
+++ b/test/risk-data-collector.test.js
@@ -72,4 +72,27 @@ describe('<RiskDataCollector />', function () {
       });
     });
   });
+
+  describe('with recurly.configuration', function () {
+    const configureSpy = jest.spyOn(global.recurly.Recurly.prototype, 'configure');
+
+    suppressConsoleErrors();
+
+    it('gives form option a DOM Element', function () {
+      const subject = withRecurlyProvider(
+        <RiskDataCollector strategy="kount" />
+      );
+
+      expect(() => render(subject)).not.toThrow();
+      expect(console.error).not.toHaveBeenCalled();
+      expect(configureSpy).toHaveBeenCalledWith({
+        fraud: {
+          kount: {
+            dataCollector: true,
+            form: expect.any(Element)
+          }
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The `<RiskDataCollector />` component should call `recurly.configure` with an instance of an HTML Form Element, but right now it's passing a `React.createRef()` object instead.

## Solution

- Pass `container.current` as the `form:` value instead of `container`.
- Add a test covering this behavior