### PR TITLE
adjust demo package to fix CodeSandbox setup

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "description": "Examples to get you started with react-recurly",
   "private": true,
+  "main": "src/index.jsx",
   "dependencies": {
-    "@recurly/react-recurly": "github:recurly/react-recurly",
+    "@recurly/react-recurly": "latest",
     "dotenv": "^16.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
fixes #219 
These changes repaired the CodeSandbox referenced within the documentation. I'll admit that I don't know the history/rationale behind directly referencing the GitHub repo as the dependency location, so this may not be an appropriate fix.

[Example sandbox](https://codesandbox.io/s/hardcore-stonebraker-397hrr?file=/package.json)