### PR TITLE
ci: Upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,22 @@ on:
     branches:
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
     name: Check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
       - name: Types
         run: make test-types
   unit_test:
     runs-on: ubuntu-latest
     name: Unit test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
       - name: Unit test
         run: make test
       - name: Report coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,6 @@ on:
       - released
 name: Documentation
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: Publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,21 +6,25 @@ on:
     types:
       - released
 name: Documentation
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.3
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v6.4.0
 
     - run: make docs-build
-    
+
     - run: touch ./build/docs/.nojekyll
 
     - if: success()
-      uses: crazy-max/ghaction-github-pages@v4
+      uses: crazy-max/ghaction-github-pages@v5.0.0
       with:
         target_branch: gh-pages
         build_dir: ./build/docs

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -14,6 +14,6 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
       - uses: stefanoeb/eslint-action@1.0.2
         continue-on-error: true


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20 as a runtime for JavaScript actions. Actions using Node.js 16 or Node.js 20 will be forced to run under Node.js 24 starting June 2026, with full removal of Node.js 20 in September 2026. Running outdated action versions after that date risks broken CI.

### Fix
Upgraded all affected GitHub Actions in this repository to their latest Node.js 24-compatible versions, verified by inspecting each action's `action.yml` at the target tag.

| Action | Before | After | Node runtime |
|--------|--------|-------|-------------|
| `actions/checkout` | `v3` / `v4` | `v6.0.3` | node24 |
| `actions/setup-node` | `v3` | `v6.4.0` | node24 |
| `crazy-max/ghaction-github-pages` | `v4` | `v5.0.0` | node24 |

Actions left unchanged (not affected):
- `stefanoeb/eslint-action@1.0.2` — Docker action, unaffected by Node.js deprecation
- `coverallsapp/github-action@v2` — composite action using pure shell scripts, no JS runtime dependency

The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable has been added to all modified workflow files for CI validation. It will be removed in a follow-up commit before merge.

### Files Changed
- `.github/workflows/ci.yml` — upgraded `actions/checkout` v3 → v6.0.3; added FORCE flag
- `.github/workflows/docs.yml` — upgraded `actions/checkout` v4 → v6.0.3, `actions/setup-node` v3 → v6.4.0, `crazy-max/ghaction-github-pages` v4 → v5.0.0; added FORCE flag
- `.github/workflows/eslint.yml` — upgraded `actions/checkout` v3 → v6.0.3

## Testing
CI runs with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to verify all actions execute correctly under Node.js 24.